### PR TITLE
feat: Add user attribute and in-app messaging methods to MoEngage ser…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 19.0.0
+- **feat:** Add MoEngage SDK integration for advanced user engagement and analytics
+
 ## 18.0.3
 
 - **fix:** Update hasActiveAnnouncements method to accept platform parameter for dynamic configuration

--- a/lib/moengage/moengage_mobile_platform.dart
+++ b/lib/moengage/moengage_mobile_platform.dart
@@ -4,12 +4,16 @@ import 'package:stoyco_shared/moengage/moengage_platform.dart';
 
 class MoEngageMobilePlatform implements MoEngagePlatform {
   late final MoEngageFlutter _moengagePlugin;
-  final MoEInitConfig _initConfig = MoEInitConfig(analyticsConfig: AnalyticsConfig(shouldTrackUserAttributeBooleanAsNumber: true));
+  final MoEInitConfig _initConfig = MoEInitConfig(
+      analyticsConfig:
+          AnalyticsConfig(shouldTrackUserAttributeBooleanAsNumber: true));
+
   @override
-  Future<void> initialize({required String appId}) async {
+  void initialize({required String appId}) {
     if (appId.isEmpty) {
       debugPrint(
-          'MoEngage Mobile: App ID es crucial para la inicialización y no fue proporcionado.',);
+        'MoEngage Mobile: App ID es crucial para la inicialización y no fue proporcionado.',
+      );
     }
 
     _moengagePlugin = MoEngageFlutter(appId, moEInitConfig: _initConfig);
@@ -17,13 +21,13 @@ class MoEngageMobilePlatform implements MoEngagePlatform {
   }
 
   @override
-  Future<void> identifyUser(String uniqueId) async {
+  void identifyUser(String uniqueId) {
     _moengagePlugin.identifyUser(uniqueId);
   }
 
   @override
-  Future<void> trackCustomEvent(
-      String eventName, Map<String, Object>? eventAttributes) async {
+  void trackCustomEvent(
+      String eventName, Map<String, Object>? eventAttributes) {
     final MoEProperties properties = MoEProperties();
     if (eventAttributes != null) {
       eventAttributes.forEach((key, value) {
@@ -32,57 +36,39 @@ class MoEngageMobilePlatform implements MoEngagePlatform {
     }
     _moengagePlugin.trackEvent(eventName, properties);
   }
-  @override
-  Future<void> setUserName(String userName) async {
-    _moengagePlugin.setUserName(userName);
-  }
-  @override
-  Future<void> setUserEmail(String email) async {
-    _moengagePlugin.setEmail(email);
-  }
 
   @override
-  Future<void> setPhoneNumber(String phoneNumber)async {
-   _moengagePlugin.setPhoneNumber(phoneNumber);
-  }
+  void setUserName(String userName) => _moengagePlugin.setUserName(userName);
 
   @override
-  Future<void> setGender(MoEGender gender)async {
-   _moengagePlugin.setGender(gender);
-  }
+  void setUserEmail(String email) => _moengagePlugin.setEmail(email);
 
   @override
-  Future<void> setLastName(String lastName) async{
-   _moengagePlugin.setLastName(lastName);
-  }
+  void setPhoneNumber(String phoneNumber) =>
+      _moengagePlugin.setPhoneNumber(phoneNumber);
 
   @override
-  Future<void> setFirstName(String firstName) async {
-    _moengagePlugin.setFirstName(firstName);
-  }
+  void setGender(MoEGender gender) => _moengagePlugin.setGender(gender);
 
   @override
-  Future<void> setUserAttribute(
-      String attributeName, dynamic attributeValue) async {
-    _moengagePlugin.setUserAttribute(attributeName, attributeValue);
-  }
+  void setLastName(String lastName) => _moengagePlugin.setLastName(lastName);
 
   @override
-  Future<void> logout() async {
-    _moengagePlugin.logout();
-  }
+  void setFirstName(String firstName) =>
+      _moengagePlugin.setFirstName(firstName);
 
   @override
-  Future<void> showInAppMessage() async {
-    _moengagePlugin.showInApp();
-  }
+  void setUserAttribute(String attributeName, dynamic attributeValue) =>
+      _moengagePlugin.setUserAttribute(attributeName, attributeValue);
 
   @override
-  Future<void> showNudge() async {
-    _moengagePlugin.showNudge();
-  }
+  void logout() => _moengagePlugin.logout();
 
+  @override
+  void showInAppMessage() => _moengagePlugin.showInApp();
 
+  @override
+  void showNudge() => _moengagePlugin.showNudge();
 
   void _setupInAppCallbacks() {
     _moengagePlugin.setInAppClickHandler(_onInAppClick);
@@ -93,11 +79,13 @@ class MoEngageMobilePlatform implements MoEngagePlatform {
 
   ///TODO METODOS DE INAPP A IMPLEMENTAR SEGUN NECESIDADES
   void _onInAppClick(ClickData message) {
-    debugPrint("MoEngage Mobile: InApp Clicked. Payload: ${message.toString()}");
+    debugPrint(
+        "MoEngage Mobile: InApp Clicked. Payload: ${message.toString()}");
     final action = message.action;
     if (action is NavigationAction) {
       if (action.navigationType == NavigationType.screenName) {
-        debugPrint("Acción de navegación a la pantalla: ${action.navigationUrl}");
+        debugPrint(
+            "Acción de navegación a la pantalla: ${action.navigationUrl}");
         // Ejemplo: navigatorKey.currentState?.pushNamed(action.navigationUrl);
       } else if (action.navigationType == NavigationType.deeplink) {
         debugPrint("Acción de deep link: ${action.navigationUrl}");
@@ -106,20 +94,20 @@ class MoEngageMobilePlatform implements MoEngagePlatform {
     }
   }
 
-
   void _onInAppShown(InAppData message) {
-    debugPrint("MoEngage Mobile: InApp Shown. Campaign: ${message.campaignData.campaignName}");
+    debugPrint(
+        "MoEngage Mobile: InApp Shown. Campaign: ${message.campaignData.campaignName}");
   }
-
 
   void _onInAppDismissed(InAppData message) {
-    debugPrint("MoEngage Mobile: InApp Dismissed. Campaign: ${message.campaignData.campaignName}");
+    debugPrint(
+        "MoEngage Mobile: InApp Dismissed. Campaign: ${message.campaignData.campaignName}");
   }
-
 
   void _onInAppSelfHandled(SelfHandledCampaignData? message) {
     if (message != null) {
-      debugPrint("MoEngage Mobile: Self-Handled InApp disponible. Payload: ${message.campaign.payload}");
+      debugPrint(
+          "MoEngage Mobile: Self-Handled InApp disponible. Payload: ${message.campaign.payload}");
     }
   }
 }

--- a/lib/moengage/moengage_mobile_platform.dart
+++ b/lib/moengage/moengage_mobile_platform.dart
@@ -12,8 +12,8 @@ class MoEngageMobilePlatform implements MoEngagePlatform {
           'MoEngage Mobile: App ID es crucial para la inicialización y no fue proporcionado.',);
     }
 
-    _moengagePlugin = MoEngageFlutter(appId,moEInitConfig: _initConfig);
-
+    _moengagePlugin = MoEngageFlutter(appId, moEInitConfig: _initConfig);
+    _setupInAppCallbacks();
     debugPrint("MoEngage Mobile: SDK inicializado con App ID: $appId");
   }
 
@@ -35,6 +35,31 @@ class MoEngageMobilePlatform implements MoEngagePlatform {
     _moengagePlugin.trackEvent(eventName, properties);
     debugPrint("MoEngage Mobile: Evento '$eventName' rastreado.");
   }
+  @override
+  Future<void> setUserName(String userName) async {
+    _moengagePlugin.setUserName(userName);
+    debugPrint("MoEngage Mobile: Nombre de usuario establecido a '$userName'.");
+  }
+  @override
+  Future<void> setUserEmail(String email) async {
+    _moengagePlugin.setEmail(email);
+    debugPrint("MoEngage Mobile: Email de usuario establecido a '$email'.");
+  }
+
+  @override
+  Future<void> setPhoneNumber(String phoneNumber)async {
+   _moengagePlugin.setPhoneNumber(phoneNumber);
+  }
+
+  @override
+  Future<void> setGender(MoEGender gender)async {
+   _moengagePlugin.setGender(gender);
+  }
+
+  @override
+  Future<void> setLastName(String lastName) async{
+   _moengagePlugin.setLastName(lastName);
+  }
 
   @override
   Future<void> setUserAttribute(
@@ -47,5 +72,65 @@ class MoEngageMobilePlatform implements MoEngagePlatform {
   Future<void> logout() async {
     _moengagePlugin.logout();
     debugPrint("MoEngage Mobile: Usuario deslogueado.");
+  }
+
+  @override
+  Future<void> showInAppMessage() async {
+    _moengagePlugin.showInApp();
+    debugPrint("MoEngage Mobile: Intentando mostrar un In-App Message.");
+  }
+
+  @override
+  Future<void> showNudge() async {
+    _moengagePlugin.showNudge();
+    debugPrint("MoEngage Mobile: Intentando mostrar un Nudge.");
+  }
+
+
+
+  void _setupInAppCallbacks() {
+    _moengagePlugin.setInAppClickHandler(_onInAppClick);
+    _moengagePlugin.setInAppShownCallbackHandler(_onInAppShown);
+    _moengagePlugin.setInAppDismissedCallbackHandler(_onInAppDismissed);
+    _moengagePlugin.setSelfHandledInAppHandler(_onInAppSelfHandled);
+    debugPrint("MoEngage Mobile: Callbacks de In-App configurados.");
+  }
+
+
+  void _onInAppClick(ClickData message) {
+    debugPrint("MoEngage Mobile: InApp Clicked. Payload: ${message.toString()}");
+    final action = message.action;
+    if (action is NavigationAction) {
+      if (action.navigationType == NavigationType.screenName) {
+        debugPrint("Acción de navegación a la pantalla: ${action.navigationUrl}");
+        // Ejemplo: navigatorKey.currentState?.pushNamed(action.navigationUrl);
+      } else if (action.navigationType == NavigationType.deeplink) {
+        debugPrint("Acción de deep link: ${action.navigationUrl}");
+        // Lógica para manejar el deep link
+      }
+    }
+  }
+
+
+  void _onInAppShown(InAppData message) {
+    debugPrint("MoEngage Mobile: InApp Shown. Campaign: ${message.campaignData.campaignName}");
+  }
+
+
+  void _onInAppDismissed(InAppData message) {
+    debugPrint("MoEngage Mobile: InApp Dismissed. Campaign: ${message.campaignData.campaignName}");
+  }
+
+
+  void _onInAppSelfHandled(SelfHandledCampaignData? message) {
+    if (message != null) {
+      debugPrint("MoEngage Mobile: Self-Handled InApp disponible. Payload: ${message.campaign.payload}");
+    }
+  }
+
+  @override
+  Future<void> setFirstName(String firstName) async {
+    _moengagePlugin.setFirstName(firstName);
+    debugPrint("MoEngage Mobile: Nombre de usuario establecido a '$firstName'.");
   }
 }

--- a/lib/moengage/moengage_mobile_platform.dart
+++ b/lib/moengage/moengage_mobile_platform.dart
@@ -14,13 +14,11 @@ class MoEngageMobilePlatform implements MoEngagePlatform {
 
     _moengagePlugin = MoEngageFlutter(appId, moEInitConfig: _initConfig);
     _setupInAppCallbacks();
-    debugPrint("MoEngage Mobile: SDK inicializado con App ID: $appId");
   }
 
   @override
   Future<void> identifyUser(String uniqueId) async {
     _moengagePlugin.identifyUser(uniqueId);
-    debugPrint("MoEngage Mobile: Usuario identificado con ID: $uniqueId");
   }
 
   @override
@@ -33,17 +31,14 @@ class MoEngageMobilePlatform implements MoEngagePlatform {
       });
     }
     _moengagePlugin.trackEvent(eventName, properties);
-    debugPrint("MoEngage Mobile: Evento '$eventName' rastreado.");
   }
   @override
   Future<void> setUserName(String userName) async {
     _moengagePlugin.setUserName(userName);
-    debugPrint("MoEngage Mobile: Nombre de usuario establecido a '$userName'.");
   }
   @override
   Future<void> setUserEmail(String email) async {
     _moengagePlugin.setEmail(email);
-    debugPrint("MoEngage Mobile: Email de usuario establecido a '$email'.");
   }
 
   @override
@@ -62,28 +57,29 @@ class MoEngageMobilePlatform implements MoEngagePlatform {
   }
 
   @override
+  Future<void> setFirstName(String firstName) async {
+    _moengagePlugin.setFirstName(firstName);
+  }
+
+  @override
   Future<void> setUserAttribute(
       String attributeName, dynamic attributeValue) async {
     _moengagePlugin.setUserAttribute(attributeName, attributeValue);
-    debugPrint("MoEngage Mobile: Atributo de usuario '$attributeName' establecido.");
   }
 
   @override
   Future<void> logout() async {
     _moengagePlugin.logout();
-    debugPrint("MoEngage Mobile: Usuario deslogueado.");
   }
 
   @override
   Future<void> showInAppMessage() async {
     _moengagePlugin.showInApp();
-    debugPrint("MoEngage Mobile: Intentando mostrar un In-App Message.");
   }
 
   @override
   Future<void> showNudge() async {
     _moengagePlugin.showNudge();
-    debugPrint("MoEngage Mobile: Intentando mostrar un Nudge.");
   }
 
 
@@ -93,10 +89,9 @@ class MoEngageMobilePlatform implements MoEngagePlatform {
     _moengagePlugin.setInAppShownCallbackHandler(_onInAppShown);
     _moengagePlugin.setInAppDismissedCallbackHandler(_onInAppDismissed);
     _moengagePlugin.setSelfHandledInAppHandler(_onInAppSelfHandled);
-    debugPrint("MoEngage Mobile: Callbacks de In-App configurados.");
   }
 
-
+  ///TODO METODOS DE INAPP A IMPLEMENTAR SEGUN NECESIDADES
   void _onInAppClick(ClickData message) {
     debugPrint("MoEngage Mobile: InApp Clicked. Payload: ${message.toString()}");
     final action = message.action;
@@ -126,11 +121,5 @@ class MoEngageMobilePlatform implements MoEngagePlatform {
     if (message != null) {
       debugPrint("MoEngage Mobile: Self-Handled InApp disponible. Payload: ${message.campaign.payload}");
     }
-  }
-
-  @override
-  Future<void> setFirstName(String firstName) async {
-    _moengagePlugin.setFirstName(firstName);
-    debugPrint("MoEngage Mobile: Nombre de usuario establecido a '$firstName'.");
   }
 }

--- a/lib/moengage/moengage_platform.dart
+++ b/lib/moengage/moengage_platform.dart
@@ -8,9 +8,9 @@ abstract class MoEngagePlatform {
   ///
   /// Example:
   /// ```dart
-  /// await MoEngagePlatform.instance.initialize(appId: "YOUR_MOENGAGE_APP_ID");
+  ///  MoEngagePlatform.instance.initialize(appId: "YOUR_MOENGAGE_APP_ID");
   /// ```
-  Future<void> initialize({required String appId});
+  void initialize({required String appId});
 
   /// Identifies the user with a unique ID.
   ///
@@ -20,9 +20,9 @@ abstract class MoEngagePlatform {
   ///
   /// Example:
   /// ```dart
-  /// await MoEngagePlatform.instance.identifyUser("user_12345");
+  ///  MoEngagePlatform.instance.identifyUser("user_12345");
   /// ```
-  Future<void> identifyUser(String uniqueId);
+  void identifyUser(String uniqueId);
 
   /// Tracks a custom event with optional attributes.
   ///
@@ -32,7 +32,7 @@ abstract class MoEngagePlatform {
   ///
   /// Example:
   /// ```dart
-  /// await MoEngagePlatform.instance.trackCustomEvent(
+  ///  MoEngagePlatform.instance.trackCustomEvent(
   ///   "Product Viewed",
   ///   {
   ///     "Product Name": "Awesome Gadget",
@@ -43,12 +43,12 @@ abstract class MoEngagePlatform {
   /// );
   ///
   /// // Tracking an event without attributes
-  /// await MoEngagePlatform.instance.trackCustomEvent("App Launched", null);
+  ///  MoEngagePlatform.instance.trackCustomEvent("App Launched", null);
   /// ```
-  Future<void> trackCustomEvent(
-      String eventName,
-      Map<String, Object>? eventAttributes,
-      );
+  void trackCustomEvent(
+    String eventName,
+    Map<String, Object>? eventAttributes,
+  );
 
   /// Sets an attribute for the current user.
   ///
@@ -58,11 +58,11 @@ abstract class MoEngagePlatform {
   ///
   /// Example:
   /// ```dart
-  /// await MoEngagePlatform.instance.setUserAttribute("User Tier", "Premium");
-  /// await MoEngagePlatform.instance.setUserAttribute("Last Login Date", DateTime.now().toIso8601String());
-  /// await MoEngagePlatform.instance.setUserAttribute("Is Subscriber", true);
+  ///  MoEngagePlatform.instance.setUserAttribute("User Tier", "Premium");
+  ///  MoEngagePlatform.instance.setUserAttribute("Last Login Date", DateTime.now().toIso8601String());
+  ///  MoEngagePlatform.instance.setUserAttribute("Is Subscriber", true);
   /// ```
-  Future<void> setUserAttribute(String attributeName, dynamic attributeValue);
+  void setUserAttribute(String attributeName, dynamic attributeValue);
 
   /// Logs out the current user from MoEngage.
   ///
@@ -72,9 +72,9 @@ abstract class MoEngagePlatform {
   ///
   /// Example:
   /// ```dart
-  /// await MoEngagePlatform.instance.logout();
+  ///  MoEngagePlatform.instance.logout();
   /// ```
-  Future<void> logout();
+  void logout();
 
   /// Shows an in-app message if there is any campaign available.
   ///
@@ -83,9 +83,9 @@ abstract class MoEngagePlatform {
   ///
   /// Example:
   /// ```dart
-  /// await MoEngagePlatform.instance.showInAppMessage();
+  ///  MoEngagePlatform.instance.showInAppMessage();
   /// ```
-  Future<void> showInAppMessage();
+  void showInAppMessage();
 
   /// Shows a nudge if there is any campaign available.
   ///
@@ -94,9 +94,9 @@ abstract class MoEngagePlatform {
   ///
   /// Example:
   /// ```dart
-  /// await MoEngagePlatform.instance.showNudge();
+  ///  MoEngagePlatform.instance.showNudge();
   /// ```
-  Future<void> showNudge();
+  void showNudge();
 
   /// Sets the user's full name.
   ///
@@ -104,9 +104,9 @@ abstract class MoEngagePlatform {
   ///
   /// Example:
   /// ```dart
-  /// await MoEngagePlatform.instance.setUserName("John Doe");
+  ///  MoEngagePlatform.instance.setUserName("John Doe");
   /// ```
-  Future<void> setUserName(String userName);
+  void setUserName(String userName);
 
   /// Sets the user's email address.
   ///
@@ -114,9 +114,9 @@ abstract class MoEngagePlatform {
   ///
   /// Example:
   /// ```dart
-  /// await MoEngagePlatform.instance.setUserEmail("john.doe@example.com");
+  ///  MoEngagePlatform.instance.setUserEmail("john.doe@example.com");
   /// ```
-  Future<void> setUserEmail(String email);
+  void setUserEmail(String email);
 
   /// Sets the user's gender.
   ///
@@ -127,22 +127,22 @@ abstract class MoEngagePlatform {
   /// ```dart
   /// import 'package:moengage_flutter/moengage_flutter.dart';
   /// // ...
-  /// await MoEngagePlatform.instance.setGender(MoEGender.male);
+  ///  MoEngagePlatform.instance.setGender(MoEGender.male);
   /// // Or for other options: MoEGender.female, MoEGender.notSpecified
   /// ```
-  Future<void> setGender(MoEGender gender);
+  void setGender(MoEGender gender);
 
-/// Sets the user's phone number.
-///
-/// Use this to store the user's phone number as a standard user attribute in MoEngage.
-///
-/// Example:
-/// ```dart
-/// await MoEngagePlatform.instance.setPhoneNumber("+1-555-123-4567");
-///
-///
-/// ```
-  Future<void> setPhoneNumber(String phoneNumber);
+  /// Sets the user's phone number.
+  ///
+  /// Use this to store the user's phone number as a standard user attribute in MoEngage.
+  ///
+  /// Example:
+  /// ```dart
+  ///  MoEngagePlatform.instance.setPhoneNumber("+1-555-123-4567");
+  ///
+  ///
+  /// ```
+  void setPhoneNumber(String phoneNumber);
 
   /// Sets the user's last name.
   ///
@@ -150,9 +150,9 @@ abstract class MoEngagePlatform {
   ///
   /// Example:
   /// ```dart
-  /// await MoEngagePlatform.instance.setLastName("Doe");
+  ///  MoEngagePlatform.instance.setLastName("Doe");
   /// ```
-  Future<void> setLastName(String lastName);
+  void setLastName(String lastName);
 
   /// Sets the user's first name.
   ///
@@ -160,7 +160,7 @@ abstract class MoEngagePlatform {
   ///
   /// Example:
   /// ```dart
-  /// await MoEngagePlatform.instance.setFirstName("John");
+  ///  MoEngagePlatform.instance.setFirstName("John");
   /// ```
-  Future<void> setFirstName(String firstName);
+  void setFirstName(String firstName);
 }

--- a/lib/moengage/moengage_platform.dart
+++ b/lib/moengage/moengage_platform.dart
@@ -2,39 +2,165 @@ import 'package:moengage_flutter/moengage_flutter.dart';
 
 abstract class MoEngagePlatform {
   /// Initializes the MoEngage SDK with the specific App ID.
+  ///
+  /// This method must be called before any other MoEngage SDK methods
+  /// to ensure proper functionality and tracking.
+  ///
+  /// Example:
+  /// ```dart
+  /// await MoEngagePlatform.instance.initialize(appId: "YOUR_MOENGAGE_APP_ID");
+  /// ```
   Future<void> initialize({required String appId});
 
   /// Identifies the user with a unique ID.
+  ///
+  /// This should be called when a user logs in or is uniquely identified
+  /// within your application. This associates all subsequent events
+  /// and user attributes with this specific user.
+  ///
+  /// Example:
+  /// ```dart
+  /// await MoEngagePlatform.instance.identifyUser("user_12345");
+  /// ```
   Future<void> identifyUser(String uniqueId);
 
   /// Tracks a custom event with optional attributes.
-  Future<void> trackCustomEvent(String eventName,
-      Map<String, Object>? eventAttributes,);
+  ///
+  /// Use this to track specific actions or behaviors of users within your app.
+  /// Attributes provide additional context about the event, allowing for
+  /// richer analytics and segmentation.
+  ///
+  /// Example:
+  /// ```dart
+  /// await MoEngagePlatform.instance.trackCustomEvent(
+  ///   "Product Viewed",
+  ///   {
+  ///     "Product Name": "Awesome Gadget",
+  ///     "Product ID": 12345,
+  ///     "Category": "Electronics",
+  ///     "Price": 99.99,
+  ///   },
+  /// );
+  ///
+  /// // Tracking an event without attributes
+  /// await MoEngagePlatform.instance.trackCustomEvent("App Launched", null);
+  /// ```
+  Future<void> trackCustomEvent(
+      String eventName,
+      Map<String, Object>? eventAttributes,
+      );
 
   /// Sets an attribute for the current user.
+  ///
+  /// This allows you to store custom data points about your users,
+  /// which can be used for segmentation, personalization, and filtering.
+  /// The `attributeValue` can be of various types like `String`, `int`, `double`, `bool`, `DateTime`.
+  ///
+  /// Example:
+  /// ```dart
+  /// await MoEngagePlatform.instance.setUserAttribute("User Tier", "Premium");
+  /// await MoEngagePlatform.instance.setUserAttribute("Last Login Date", DateTime.now().toIso8601String());
+  /// await MoEngagePlatform.instance.setUserAttribute("Is Subscriber", true);
+  /// ```
   Future<void> setUserAttribute(String attributeName, dynamic attributeValue);
 
   /// Logs out the current user from MoEngage.
+  ///
+  /// This method should be called when a user logs out of your application.
+  /// It clears the current user's identity and starts a new session for an
+  /// anonymous user, or for a new user if `identifyUser` is called subsequently.
+  ///
+  /// Example:
+  /// ```dart
+  /// await MoEngagePlatform.instance.logout();
+  /// ```
   Future<void> logout();
 
-  ///show in app message if there is any campaign available.
-  ///Only works on Android and iOS.
+  /// Shows an in-app message if there is any campaign available.
+  ///
+  /// This method triggers the display of a MoEngage in-app message
+  /// configured for the current user and context. Only works on Android and iOS.
+  ///
+  /// Example:
+  /// ```dart
+  /// await MoEngagePlatform.instance.showInAppMessage();
+  /// ```
   Future<void> showInAppMessage();
 
-  ///show nudge if there is any campaign available.
-  ///Only works on Android and iOS.
+  /// Shows a nudge if there is any campaign available.
+  ///
+  /// This method triggers the display of a MoEngage nudge campaign
+  /// configured for the current user and context. Only works on Android and iOS.
+  ///
+  /// Example:
+  /// ```dart
+  /// await MoEngagePlatform.instance.showNudge();
+  /// ```
   Future<void> showNudge();
 
-  /// Sets the user's name.
+  /// Sets the user's full name.
+  ///
+  /// Use this to store the user's full name as a standard user attribute in MoEngage.
+  ///
+  /// Example:
+  /// ```dart
+  /// await MoEngagePlatform.instance.setUserName("John Doe");
+  /// ```
   Future<void> setUserName(String userName);
-  /// Sets the user's email.
+
+  /// Sets the user's email address.
+  ///
+  /// Use this to store the user's email as a standard user attribute in MoEngage.
+  ///
+  /// Example:
+  /// ```dart
+  /// await MoEngagePlatform.instance.setUserEmail("john.doe@example.com");
+  /// ```
   Future<void> setUserEmail(String email);
+
   /// Sets the user's gender.
+  ///
+  /// Use this to store the user's gender as a standard user attribute in MoEngage.
+  /// The `MoEGender` enum is part of `package:moengage_flutter/moengage_flutter.dart`.
+  ///
+  /// Example:
+  /// ```dart
+  /// import 'package:moengage_flutter/moengage_flutter.dart';
+  /// // ...
+  /// await MoEngagePlatform.instance.setGender(MoEGender.male);
+  /// // Or for other options: MoEGender.female, MoEGender.notSpecified
+  /// ```
   Future<void> setGender(MoEGender gender);
-  /// Sets the user's phone number.
+
+/// Sets the user's phone number.
+///
+/// Use this to store the user's phone number as a standard user attribute in MoEngage.
+///
+/// Example:
+/// ```dart
+/// await MoEngagePlatform.instance.setPhoneNumber("+1-555-123-4567");
+///
+///
+/// ```
   Future<void> setPhoneNumber(String phoneNumber);
+
   /// Sets the user's last name.
+  ///
+  /// Use this to store the user's last name as a standard user attribute in MoEngage.
+  ///
+  /// Example:
+  /// ```dart
+  /// await MoEngagePlatform.instance.setLastName("Doe");
+  /// ```
   Future<void> setLastName(String lastName);
+
   /// Sets the user's first name.
+  ///
+  /// Use this to store the user's first name as a standard user attribute in MoEngage.
+  ///
+  /// Example:
+  /// ```dart
+  /// await MoEngagePlatform.instance.setFirstName("John");
+  /// ```
   Future<void> setFirstName(String firstName);
 }

--- a/lib/moengage/moengage_platform.dart
+++ b/lib/moengage/moengage_platform.dart
@@ -1,3 +1,5 @@
+import 'package:moengage_flutter/moengage_flutter.dart';
+
 abstract class MoEngagePlatform {
   /// Initializes the MoEngage SDK with the specific App ID.
   Future<void> initialize({required String appId});
@@ -14,4 +16,25 @@ abstract class MoEngagePlatform {
 
   /// Logs out the current user from MoEngage.
   Future<void> logout();
+
+  ///show in app message if there is any campaign available.
+  ///Only works on Android and iOS.
+  Future<void> showInAppMessage();
+
+  ///show nudge if there is any campaign available.
+  ///Only works on Android and iOS.
+  Future<void> showNudge();
+
+  /// Sets the user's name.
+  Future<void> setUserName(String userName);
+  /// Sets the user's email.
+  Future<void> setUserEmail(String email);
+  /// Sets the user's gender.
+  Future<void> setGender(MoEGender gender);
+  /// Sets the user's phone number.
+  Future<void> setPhoneNumber(String phoneNumber);
+  /// Sets the user's last name.
+  Future<void> setLastName(String lastName);
+  /// Sets the user's first name.
+  Future<void> setFirstName(String firstName);
 }

--- a/lib/moengage/moengage_service.dart
+++ b/lib/moengage/moengage_service.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/foundation.dart';
+import 'package:moengage_flutter/moengage_flutter.dart';
 import 'package:stoyco_shared/moengage/moengage_platform.dart';
 import 'package:stoyco_shared/moengage/platform_locator.dart'
 if (dart.library.io) 'platform_locator_mobile.dart'
@@ -35,7 +36,52 @@ class MoEngageService {
     await _platform.setUserAttribute(name, value);
   }
 
+  Future<void> showInAppMessage() async {
+    await _platform.showInAppMessage();
+  }
+
+  Future<void> showNudge() async {
+    await _platform.showNudge();
+  }
+
   Future<void> logout() async {
     await _platform.logout();
   }
+
+  Future<void> setUserName(String userName) async {
+    await _platform.setUserName(userName);
+  }
+  Future<void> setUserEmail(String email) async {
+    await _platform.setUserEmail(email);
+  }
+
+  Future<void> setGender(String gender) async {
+    final MoEGender genderEnum = stringToGender(gender);
+    await _platform.setGender(genderEnum);
+  }
+
+  Future<void> setPhoneNumber(String phoneNumber) async {
+    await _platform.setPhoneNumber(phoneNumber);
+  }
+
+  Future<void> setLastName(String lastName) async {
+    await _platform.setLastName(lastName);
+  }
+
+  Future<void> setFirstName(String firstName) async {
+    await _platform.setFirstName(firstName);
+  }
+  MoEGender stringToGender(String gender) {
+    switch (gender.toLowerCase()) {
+      case 'masculino':
+        return MoEGender.male;
+      case 'femenino':
+        return MoEGender.female;
+      case 'otro':
+        return MoEGender.other;
+      default:
+        return MoEGender.other;
+    }
+  }
+
 }

--- a/lib/moengage/moengage_service.dart
+++ b/lib/moengage/moengage_service.dart
@@ -2,14 +2,15 @@ import 'package:flutter/foundation.dart';
 import 'package:moengage_flutter/moengage_flutter.dart';
 import 'package:stoyco_shared/moengage/moengage_platform.dart';
 import 'package:stoyco_shared/moengage/platform_locator.dart'
-if (dart.library.io) 'platform_locator_mobile.dart'
-if (dart.library.html) 'platform_locator_web.dart';
+    if (dart.library.io) 'platform_locator_mobile.dart'
+    if (dart.library.html) 'platform_locator_web.dart';
 
 class MoEngageService {
   MoEngageService._internal([MoEngagePlatform? platform]) {
     _platform = platform ?? getMoEngagePlatform();
     debugPrint('MoEngageService: Plataforma seleccionada por el compilador.');
   }
+
   static MoEngageService? _instance;
   late final MoEngagePlatform _platform;
 
@@ -18,59 +19,43 @@ class MoEngageService {
     return _instance!;
   }
 
-  static Future<MoEngageService> init({required String appId, MoEngagePlatform? platform}) async {
+  static MoEngageService init(
+      {required String appId, MoEngagePlatform? platform}) {
     _instance = MoEngageService._internal(platform);
-    await _instance!._platform.initialize(appId: appId);
+    _instance!._platform.initialize(appId: appId);
     return _instance!;
   }
 
-  Future<void> setUniqueId(String uniqueId) async {
-    await _platform.identifyUser(uniqueId);
-  }
+  void setUniqueId(String uniqueId) => _platform.identifyUser(uniqueId);
 
-  Future<void> trackCustomEvent(String eventName, {Map<String, Object>? attributes}) async {
-    await _platform.trackCustomEvent(eventName, attributes);
-  }
+  void trackCustomEvent(String eventName, {Map<String, Object>? attributes}) =>
+      _platform.trackCustomEvent(eventName, attributes);
 
-  Future<void> setUserAttribute(String name, dynamic value) async {
-    await _platform.setUserAttribute(name, value);
-  }
+  void setUserAttribute(String name, dynamic value) =>
+      _platform.setUserAttribute(name, value);
 
-  Future<void> showInAppMessage() async {
-    await _platform.showInAppMessage();
-  }
+  void showInAppMessage() => _platform.showInAppMessage();
 
-  Future<void> showNudge() async {
-    await _platform.showNudge();
-  }
+  void showNudge() => _platform.showNudge();
 
-  Future<void> logout() async {
-    await _platform.logout();
-  }
+  void logout() => _platform.logout();
 
-  Future<void> setUserName(String userName) async {
-    await _platform.setUserName(userName);
-  }
-  Future<void> setUserEmail(String email) async {
-    await _platform.setUserEmail(email);
-  }
+  void setUserName(String userName) => _platform.setUserName(userName);
 
-  Future<void> setGender(String gender) async {
+  void setUserEmail(String email) => _platform.setUserEmail(email);
+
+  void setGender(String gender) {
     final MoEGender genderEnum = stringToGender(gender);
-    await _platform.setGender(genderEnum);
+    _platform.setGender(genderEnum);
   }
 
-  Future<void> setPhoneNumber(String phoneNumber) async {
-    await _platform.setPhoneNumber(phoneNumber);
-  }
+  void setPhoneNumber(String phoneNumber) =>
+      _platform.setPhoneNumber(phoneNumber);
 
-  Future<void> setLastName(String lastName) async {
-    await _platform.setLastName(lastName);
-  }
+  void setLastName(String lastName) => _platform.setLastName(lastName);
 
-  Future<void> setFirstName(String firstName) async {
-    await _platform.setFirstName(firstName);
-  }
+  void setFirstName(String firstName) => _platform.setFirstName(firstName);
+
   MoEGender stringToGender(String gender) {
     switch (gender.toLowerCase()) {
       case 'masculino':
@@ -83,5 +68,4 @@ class MoEngageService {
         return MoEGender.other;
     }
   }
-
 }

--- a/lib/moengage/moengage_web_platform.dart
+++ b/lib/moengage/moengage_web_platform.dart
@@ -7,7 +7,7 @@ class MoEngageWebPlatform implements MoEngagePlatform {
   String? _appId;
 
   @override
-  Future<void> initialize({String? appId}) async {
+  void initialize({String? appId}) {
     _appId = appId;
 
     print("MoEngage Web: Plataforma inicializada. "
@@ -16,7 +16,8 @@ class MoEngageWebPlatform implements MoEngagePlatform {
   }
 
   @override
-  Future<void> trackCustomEvent(String eventName, Map<String, dynamic>? eventAttributes) async {
+  void trackCustomEvent(
+      String eventName, Map<String, dynamic>? eventAttributes) {
     final MoEProperties properties = MoEProperties();
 
     if (eventAttributes != null) {
@@ -24,64 +25,54 @@ class MoEngageWebPlatform implements MoEngagePlatform {
         properties.addAttribute(key, value);
       });
     }
-    _moengagePlugin.trackEvent(eventName, properties,_appId!);
+    _moengagePlugin.trackEvent(eventName, properties, _appId!);
   }
 
   @override
-  Future<void> identifyUser(String uniqueId) async {
-    _moengagePlugin.setUniqueId(uniqueId,_appId!);
-  }
+  void identifyUser(String uniqueId) =>
+      _moengagePlugin.setUniqueId(uniqueId, _appId!);
 
   @override
-  Future<void> setUserAttribute(String attributeName, dynamic attributeValue) async {
+  void setUserAttribute(String attributeName, dynamic attributeValue) {
     if (attributeValue is DateTime) {
-      _moengagePlugin.setUserAttribute(attributeName, attributeValue.toIso8601String(),_appId!);
+      _moengagePlugin.setUserAttribute(
+          attributeName, attributeValue.toIso8601String(), _appId!);
     } else {
-      _moengagePlugin.setUserAttribute(attributeName, attributeValue,_appId!);
+      _moengagePlugin.setUserAttribute(attributeName, attributeValue, _appId!);
     }
   }
 
   @override
-  Future<void> logout() async {
-    _moengagePlugin.logout(_appId!);
-  }
+  void logout() => _moengagePlugin.logout(_appId!);
 
   @override
-  Future<void> showInAppMessage() async {
-    // NO-OP
-    throw UnimplementedError(
-        "MoEngage Web: showInAppMessage no está implementado en Web.");
-  }
+  void showInAppMessage() => throw UnimplementedError(
+      "MoEngage Web: showInAppMessage no está implementado en Web.");
 
   @override
-  Future<void> showNudge() async {
-    throw UnimplementedError("MoEngage Web: showInAppMessage no está implementado en Web.");
-  }
-  @override
-  Future<void> setUserName(String userName) async {
-    _moengagePlugin.setUserName(userName,_appId!);
-  }
-  @override
-  Future<void> setUserEmail(String email) async {
-    _moengagePlugin.setEmail(email,_appId!);
-  }
+  void showNudge() => throw UnimplementedError(
+      "MoEngage Web: showInAppMessage no está implementado en Web.");
 
   @override
-  Future<void> setGender(MoEGender gender) async {
-   _moengagePlugin.setGender(gender, _appId!);
-  }
-  @override
-  Future<void> setPhoneNumber(String phoneNumber) async {
-    _moengagePlugin.setPhoneNumber(phoneNumber,_appId!);
-  }
+  void setUserName(String userName) =>
+      _moengagePlugin.setUserName(userName, _appId!);
 
   @override
-  Future<void> setLastName(String lastName) async {
-   _moengagePlugin.setLastName(lastName,_appId!);
-  }
+  void setUserEmail(String email) => _moengagePlugin.setEmail(email, _appId!);
 
   @override
-  Future<void> setFirstName(String firstName) async {
-   _moengagePlugin.setFirstName(firstName,_appId!);
-  }
+  void setGender(MoEGender gender) =>
+      _moengagePlugin.setGender(gender, _appId!);
+
+  @override
+  void setPhoneNumber(String phoneNumber) =>
+      _moengagePlugin.setPhoneNumber(phoneNumber, _appId!);
+
+  @override
+  void setLastName(String lastName) =>
+      _moengagePlugin.setLastName(lastName, _appId!);
+
+  @override
+  void setFirstName(String firstName) =>
+      _moengagePlugin.setFirstName(firstName, _appId!);
 }

--- a/lib/moengage/moengage_web_platform.dart
+++ b/lib/moengage/moengage_web_platform.dart
@@ -49,4 +49,47 @@ class MoEngageWebPlatform implements MoEngagePlatform {
     _moengagePlugin.logout(_appId!);
     print("MoEngage Web: Usuario deslogueado.");
   }
+
+  @override
+  Future<void> showInAppMessage() async {
+    // NO-OP
+    print("MoEngage Web: showInAppMessage llamado, pero es no-op en Web.");
+    return Future.value();
+  }
+
+  @override
+  Future<void> showNudge() async {
+    // NO-OP
+    print("MoEngage Web: showNudge llamado, pero es no-op en Web.");
+    return Future.value();
+  }
+  @override
+  Future<void> setUserName(String userName) async {
+    _moengagePlugin.setUserName(userName,_appId!);
+    print("MoEngage Mobile: Nombre de usuario establecido a '$userName'.");
+  }
+  @override
+  Future<void> setUserEmail(String email) async {
+    _moengagePlugin.setEmail(email,_appId!);
+    print("MoEngage Mobile: Email de usuario establecido a '$email'.");
+  }
+
+  @override
+  Future<void> setGender(MoEGender gender) async {
+   _moengagePlugin.setGender(gender, _appId!);
+  }
+  @override
+  Future<void> setPhoneNumber(String phoneNumber) async {
+    _moengagePlugin.setPhoneNumber(phoneNumber,_appId!);
+  }
+
+  @override
+  Future<void> setLastName(String lastName) async {
+   _moengagePlugin.setLastName(lastName,_appId!);
+  }
+
+  @override
+  Future<void> setFirstName(String firstName) async {
+   _moengagePlugin.setFirstName(firstName,_appId!);
+  }
 }

--- a/lib/moengage/moengage_web_platform.dart
+++ b/lib/moengage/moengage_web_platform.dart
@@ -25,13 +25,11 @@ class MoEngageWebPlatform implements MoEngagePlatform {
       });
     }
     _moengagePlugin.trackEvent(eventName, properties,_appId!);
-    print("MoEngage Web: Evento '$eventName' rastreado con atributos: $eventAttributes");
   }
 
   @override
   Future<void> identifyUser(String uniqueId) async {
     _moengagePlugin.setUniqueId(uniqueId,_appId!);
-    print("MoEngage Web: Usuario identificado con ID: $uniqueId");
   }
 
   @override
@@ -41,37 +39,31 @@ class MoEngageWebPlatform implements MoEngagePlatform {
     } else {
       _moengagePlugin.setUserAttribute(attributeName, attributeValue,_appId!);
     }
-    print("MoEngage Web: Atributo de usuario '$attributeName' establecido en '$attributeValue'");
   }
 
   @override
   Future<void> logout() async {
     _moengagePlugin.logout(_appId!);
-    print("MoEngage Web: Usuario deslogueado.");
   }
 
   @override
   Future<void> showInAppMessage() async {
     // NO-OP
-    print("MoEngage Web: showInAppMessage llamado, pero es no-op en Web.");
-    return Future.value();
+    throw UnimplementedError(
+        "MoEngage Web: showInAppMessage no está implementado en Web.");
   }
 
   @override
   Future<void> showNudge() async {
-    // NO-OP
-    print("MoEngage Web: showNudge llamado, pero es no-op en Web.");
-    return Future.value();
+    throw UnimplementedError("MoEngage Web: showInAppMessage no está implementado en Web.");
   }
   @override
   Future<void> setUserName(String userName) async {
     _moengagePlugin.setUserName(userName,_appId!);
-    print("MoEngage Mobile: Nombre de usuario establecido a '$userName'.");
   }
   @override
   Future<void> setUserEmail(String email) async {
     _moengagePlugin.setEmail(email,_appId!);
-    print("MoEngage Mobile: Email de usuario establecido a '$email'.");
   }
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: stoyco_shared
 description: A set of shared components for Stoyco Flutter projects.
-version: 18.0.3
+version: 19.0.0
 
 environment:
   sdk: ">=3.1.2 <4.0.0"

--- a/test/moengage/moengage_service_test.dart
+++ b/test/moengage/moengage_service_test.dart
@@ -14,40 +14,40 @@ void main() {
     mockPlatform = MockMoEngagePlatform();
   });
 
-  test('init calls initialize on platform', () async {
-    when(mockPlatform.initialize(appId: 'testAppId')).thenAnswer((_) async => null);
-    await MoEngageService.init(appId: 'testAppId', platform: mockPlatform);
+  test('init calls initialize on platform', ()  {
+    when(mockPlatform.initialize(appId: 'testAppId')).thenAnswer((_)  async {});
+     MoEngageService.init(appId: 'testAppId', platform: mockPlatform);
     verify(mockPlatform.initialize(appId: 'testAppId')).called(1);
   });
 
 
-  test('setUniqueId delegates to platform', () async {
-    await MoEngageService.init(appId: 'testAppId', platform: mockPlatform);
+  test('setUniqueId delegates to platform', ()  {
+     MoEngageService.init(appId: 'testAppId', platform: mockPlatform);
     when(mockPlatform.identifyUser('user123')).thenAnswer((_) async {});
-    await MoEngageService.instance.setUniqueId('user123');
+     MoEngageService.instance.setUniqueId('user123');
     verify(mockPlatform.identifyUser('user123')).called(1);
   });
 
-  test('trackCustomEvent delegates to platform', () async {
+  test('trackCustomEvent delegates to platform', ()  {
     final eventName = 'event';
     final attributes = {'key': 'value'};
     when(mockPlatform.trackCustomEvent(eventName, attributes)).thenAnswer((_) async {});
-    await MoEngageService.init(appId: 'testAppId', platform: mockPlatform);
-    await MoEngageService.instance.trackCustomEvent(eventName, attributes: attributes);
+     MoEngageService.init(appId: 'testAppId', platform: mockPlatform);
+     MoEngageService.instance.trackCustomEvent(eventName, attributes: attributes);
     verify(mockPlatform.trackCustomEvent(eventName, attributes)).called(1);
   });
 
-  test('setUserAttribute delegates to platform', () async {
+  test('setUserAttribute delegates to platform', ()  {
     when(mockPlatform.setUserAttribute('attr', 'val')).thenAnswer((_) async {});
-    await MoEngageService.init(appId: 'testAppId', platform: mockPlatform);
-    await MoEngageService.instance.setUserAttribute('attr', 'val');
+     MoEngageService.init(appId: 'testAppId', platform: mockPlatform);
+     MoEngageService.instance.setUserAttribute('attr', 'val');
     verify(mockPlatform.setUserAttribute('attr', 'val')).called(1);
   });
 
-  test('logout delegates to platform', () async {
+  test('logout delegates to platform', ()  {
     when(mockPlatform.logout()).thenAnswer((_) async {});
-    await MoEngageService.init(appId: 'testAppId', platform: mockPlatform);
-    await MoEngageService.instance.logout();
+     MoEngageService.init(appId: 'testAppId', platform: mockPlatform);
+     MoEngageService.instance.logout();
     verify(mockPlatform.logout()).called(1);
   });
 }


### PR DESCRIPTION
…vice

This commit introduces new methods to the MoEngage service and its platform implementations:

- `showInAppMessage()`: Displays in-app messages (no-op on Web).
- `showNudge()`: Shows nudge notifications (no-op on Web).
- `setUserName(String userName)`
- `setUserEmail(String email)`
- `setGender(MoEGender gender)` (with a helper `stringToGender` in `MoengageService`)
- `setPhoneNumber(String phoneNumber)`
- `setLastName(String lastName)`
- `setFirstName(String firstName)`

For the mobile platform (`moengage_mobile_platform.dart`):
- In-app message callbacks (`_onInAppClick`, `_onInAppShown`, `_onInAppDismissed`, `_onInAppSelfHandled`) are now set up during initialization.
- Logging has been added for these new methods.

For the web platform (`moengage_web_platform.dart`):
- The new user attribute methods are implemented.
- `showInAppMessage` and `showNudge` are implemented as no-op methods with corresponding log messages.

The `MoEngagePlatform` abstract class and `MoengageService` have been updated to include these new method definitions.